### PR TITLE
Fix/timeout error import

### DIFF
--- a/src/modules/bank/services/getAllBanks.ts
+++ b/src/modules/bank/services/getAllBanks.ts
@@ -2,7 +2,7 @@ import { getBaseUrl, getTimeout } from '@src/shared/config/ApiConfig';
 import { AppError } from '@src/shared/exceptions/AppError';
 import { handleResponseError } from '@src/shared/exceptions/HandlerResponseError';
 import { ServerError } from '@src/shared/exceptions/ServerError';
-import { TimeoutError } from '@src/shared/exceptions/TimeOutError';
+import { TimeoutError } from '@src/shared/exceptions/TimeoutError';
 import { Bank } from '../entities/Bank';
 
 async function getAllBanks(): Promise<Bank[]> {

--- a/src/modules/bank/services/getBankByCode.ts
+++ b/src/modules/bank/services/getBankByCode.ts
@@ -2,7 +2,7 @@ import { getBaseUrl, getTimeout } from '@src/shared/config/ApiConfig';
 import { AppError } from '@src/shared/exceptions/AppError';
 import { handleResponseError } from '@src/shared/exceptions/HandlerResponseError';
 import { ServerError } from '@src/shared/exceptions/ServerError';
-import { TimeoutError } from '@src/shared/exceptions/TimeOutError';
+import { TimeoutError } from '@src/shared/exceptions/TimeoutError';
 import { Bank } from '../entities/Bank';
 
 async function getBankByCode(bankCode: string): Promise<Bank> {

--- a/test/bank/unit/getBankByCode.test.ts
+++ b/test/bank/unit/getBankByCode.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { Bank, getBankByCode } from '@src/index';
 import { ServerError } from '@src/shared/exceptions/ServerError';
-import { TimeoutError } from '@src/shared/exceptions/TimeOutError';
+import { TimeoutError } from '@src/shared/exceptions/TimeoutError';
 import { describe, expect, it, vi } from 'vitest';
 
 describe('getBankByCode', () => {


### PR DESCRIPTION
## Descrição 
Corrige o import da exceção TimeoutError em três arquivos do módulo bank, padronizando a capitalização correta do nome do arquivo. A alteração evita conflitos em sistemas com case-sensitive e elimina warnings do TypeScript/ESLint.

## Arquivos alterados
- getAllBanks.ts
- getBankByCode.ts
- getBankByCode.test.ts