### PR TITLE
chore: change deprecated module resolution from node to nodenext and module from esnext to nodenext

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "ESNext",
+    "module": "nodenext",
     "declaration": true,
     "outDir": "dist",
-    "moduleResolution": "Node",
+    "moduleResolution": "nodenext",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,


### PR DESCRIPTION
## Descrição

Foi atualizado o tsconfig.json para utilizar as opções recomendadas pelo TypeScript para projetos em Node.js, substituindo esnext por nodenext.
Essa alteração garante maior compatibilidade com o modelo de módulos do Node.js e previne warnings futuros de depreciação.

## Principais mudanças

- Alterado "module" de esnext para nodenext.
- Alterado "moduleResolution" de node para nodenext.
- Mantida a compatibilidade com o padrão de imports import/export.

## Observações

- Como o projeto não utiliza require, não foi necessário ajustar nenhuma parte do código.
- O build e os testes continuam funcionando normalmente.